### PR TITLE
Ensure MID Server service is enabled at startup

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -12,7 +12,9 @@ class servicenow_midserver::service {
   }
 
   service{'snc_mid':
-    ensure => running
+    ensure  => running,
+    enable  => true,
+    require => Exec['Initiate ServiceNow Midserver'],
   }
 
 }


### PR DESCRIPTION
This not only enables the service on boot, it also fixes a problem with Windows on Puppet 6 where the service will not start unless it's set to be enabled.